### PR TITLE
Bug fix: set shift count on MOV and OUT

### DIFF
--- a/java/org/soundpaint/rp2040pio/Instruction.java
+++ b/java/org/soundpaint/rp2040pio/Instruction.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.IntConsumer;
+import java.util.function.Consumer;
 
 /**
  * Instruction
@@ -569,46 +569,56 @@ public abstract class Instruction
     private static final Map<Integer, Destination> code2dst =
       new HashMap<Integer, Destination>();
 
+    private class DestinationData {
+      public final int shiftOutBits;
+      public final int bitsToShift;
+      public DestinationData(int shiftOutBits, int bitsToShift) {
+        this.shiftOutBits = shiftOutBits;
+        this.bitsToShift = bitsToShift;
+      }
+    }
+
     public enum Destination
     {
       PINS(0b000, "pins", (sm, data) -> {
-          SM.IOMapping.OUT.collatePins(sm, data);
+          SM.IOMapping.OUT.collatePins(sm, data.shiftOutBits);
           return null;
         }),
       X(0b001, "x", (sm, data) -> {
-          sm.setX(data);
+          sm.setX(data.shiftOutBits);
           return null;
         }),
       Y(0b010, "y", (sm, data) -> {
-          sm.setY(data);
+          sm.setY(data.shiftOutBits);
           return null;
         }),
       NULL(0b011, "null", (sm, data) -> {
           return null;
         }),
       PINDIRS(0b100, "pindirs", (sm, data) -> {
-          SM.IOMapping.OUT.collatePinDirs(sm, data);
+          SM.IOMapping.OUT.collatePinDirs(sm, data.shiftOutBits);
           return null;
         }),
       PC(0b101, "pc", (sm, data) -> {
-          sm.setPC(data & 0x1f);
+          sm.setPC(data.shiftOutBits & 0x1f);
           return null;
         }),
       ISR(0b110, "isr", (sm, data) -> {
-          sm.setISRValue(data);
+          sm.setISRValue(data.shiftOutBits);
+          sm.setISRShiftCount(data.bitsToShift);
           return null;
         }),
       EXEC(0b111, "exec", (sm, data) -> {
-          sm.execInstruction(data);
+          sm.execInstruction(data.shiftOutBits);
           return null;
         });
 
       private final int code;
       private final String mnemonic;
-      private final BiFunction<SM, Integer, Void> eval;
+      private final BiFunction<SM, DestinationData, Void> eval;
 
       private Destination(final int code, final String mnemonic,
-                          final BiFunction<SM, Integer, Void> eval)
+                          final BiFunction<SM, DestinationData, Void> eval)
       {
         this.code = code;
         this.mnemonic = mnemonic;
@@ -616,7 +626,7 @@ public abstract class Instruction
         code2dst.put(code, this);
       }
 
-      public IntConsumer getConsumer(final SM sm)
+      public Consumer<DestinationData> getConsumer(final SM sm)
       {
         return (data) -> {
           eval.apply(sm, data);
@@ -691,7 +701,7 @@ public abstract class Instruction
       } else {
         shiftOutBits = smStatus.osrValue;
       }
-      dst.getConsumer(sm).accept(shiftOutBits);
+      dst.getConsumer(sm).accept(new DestinationData(shiftOutBits, bitsToShift));
     }
 
     private void shiftOsr(final SM sm, final SM.Status smStatus,

--- a/java/org/soundpaint/rp2040pio/Instruction.java
+++ b/java/org/soundpaint/rp2040pio/Instruction.java
@@ -954,10 +954,12 @@ public abstract class Instruction
         }),
       ISR(0b110, "isr", (sm, data) -> {
           sm.setISRValue(data);
+          sm.setISRShiftCount(0);
           return null;
         }),
       OSR(0b111, "osr", (sm, data) -> {
           sm.setOSRValue(data);
+          sm.setOSRShiftCount(0);
           return null;
         });
 

--- a/java/org/soundpaint/rp2040pio/SM.java
+++ b/java/org/soundpaint/rp2040pio/SM.java
@@ -688,6 +688,11 @@ public class SM implements Constants
 
   public int getISRShiftCount() { return status.isrShiftCount; }
 
+  public void setISRShiftCount(final int value)
+  {
+    status.isrShiftCount = value;
+  }
+
   public void setISRShiftCount(final int value, final int mask,
                                final boolean xor)
   {
@@ -708,6 +713,12 @@ public class SM implements Constants
   }
 
   public int getOSRShiftCount() { return status.osrShiftCount; }
+
+
+  public void setOSRShiftCount(final int value)
+  {
+    status.osrShiftCount = value;
+  }
 
   public void setOSRShiftCount(final int value, final int mask,
                                final boolean xor)


### PR DESCRIPTION
Hi. This is a great project. It helped me simulate a PIO algorithm for a quadrature encoder. I was also blown away by the documentation. You did such a spectacular job :clap: 

I ran into what I think is an oversight in the implementation of the MOV and OUT instructions.

According to the [RP2040 datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf), the MOV instruction clears the ISR and OSR shift counters. Additionally, when the destination for OUT instruction is the ISR register, it sets the ISR shift counter to the bit count.

![image](https://user-images.githubusercontent.com/1919681/142745437-7f1e469a-1940-4579-94d3-1d04bf4f59d5.png)

![image](https://user-images.githubusercontent.com/1919681/142745445-55761005-49fa-4ace-8ff3-6d588e9d521e.png)

I implemented the changes to the simulator. I'm providing test cases for the three operations. These test case PIO programs don't do anything useful but they show the issue and the fix.

# Steps to reproduce the issue with mov isr

```
reset
enter -a 0 -v 0xe023 #  0: set    x, 3                       
enter -a 1 -v 0x4022 #  1: in     x, 2                       
enter -a 2 -v 0xa0c3 #  2: mov    isr, null                  
enter -a 3 -v 0x0000 #  3: jmp    0                  
sm --pio=0 --sm=0 --enable=true
trace --cycles=4
registers
```

Expect ISR_SHIFT_COUNT=00000000 after `mov isr, null`, 

Before fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=03
           ISR=00000000, ISR_SHIFT_COUNT=00000002
           OSR=00000000, OSR_SHIFT_COUNT=00000020
```

After fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=03
           ISR=00000000, ISR_SHIFT_COUNT=00000000
           OSR=00000000, OSR_SHIFT_COUNT=00000020
```

# Steps to reproduce the issue with mov osr

```
reset
enter -a 0 -v 0xe023 #  0: set    x, 3                       
enter -a 1 -v 0xa0e1 #  1: mov    osr, x                     
enter -a 2 -v 0x6022 #  2: out    x, 2                       
enter -a 3 -v 0x0000 #  3: jmp    0       
fifo --tx --shift-right
sm --pio=0 --sm=0 --enable=true
trace --cycles=3
registers
```

Expect OSR_SHIFT_COUNT=00000000 after `mov osr, x`

Before fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=02
           ISR=00000000, ISR_SHIFT_COUNT=00000000
           OSR=00000003, OSR_SHIFT_COUNT=00000020
```

After fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=02
           ISR=00000000, ISR_SHIFT_COUNT=00000000
           OSR=00000003, OSR_SHIFT_COUNT=00000000
```

# Steps to reproduce the issue with out isr

```
reset
enter -a 0 -v 0xe023 #  0: set    x, 3                       
enter -a 1 -v 0xa0e1 #  1: mov    osr, x                     
enter -a 2 -v 0x60c2 #  2: out    isr, 2                     
enter -a 3 -v 0x0000 #  3: jmp    0                          
fifo --tx --shift-right
sm --pio=0 --sm=0 --enable=true
trace --cycles=4
registers
```

Expect ISR_SHIFT_COUNT=00000002 after `out isr, 2`

Before fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=03
           ISR=00000003, ISR_SHIFT_COUNT=00000000
           OSR=00000000, OSR_SHIFT_COUNT=00000020
```

After fix:
```
> (pio0:sm0) X=00000003, Y=00000000, PC=03
           ISR=00000003, ISR_SHIFT_COUNT=00000002
           OSR=00000000, OSR_SHIFT_COUNT=00000002
```